### PR TITLE
Fix `xcolor` option clash.

### DIFF
--- a/gleetex/typesetting.py
+++ b/gleetex/typesetting.py
@@ -332,10 +332,11 @@ class LaTeXDocument:
             \\documentclass[{fontsize}, fleqn]{{scrartcl}}\n
             {color_preamble}
             {preamble}
-            \\usepackage[dvipsnames]{{xcolor}}
+            \\usepackage{{xcolor}}
             {color_body}
             % tightpage must be last, see its package docs
             \\usepackage[active,textmath,displaymath,tightpage]{{preview}}\n
+            \\PassOptionsToPackage{{dvipsnames}}{{xcolor}}\n
             \\begin{{document}}\n
             \\noindent%
             \\begin{{preview}}{{%s


### PR DESCRIPTION
The invoker may supply their own statements to be added to the preamble
via the `-p` flag. These statements may use `xcolor`, directly or
indirectly. Then we would try to use `xcolor` ourselves, with the option
`divpsnames`, and this will result in the following LaTeX error:

    Option clash for package xcolor.

We hedge against this by using `xcolor` with the desired option
ourselves before executing statements supplied by the invoker.

Unfortunately, option clash will still appear if `xcolor` is used by the
statements supplied by the invoker with options. But this is less
likely… or so we hope.