### PR TITLE
Detect non-nestable math environments

### DIFF
--- a/gleetex/typesetting.py
+++ b/gleetex/typesetting.py
@@ -379,7 +379,7 @@ class LaTeXDocument:
         # *only*, as it is supposed to be a formula and to avoid complex
         # parsing. When found, such an environment is not wrapped.
         envs_list = '|'.join(re.escape(env) for env in NON_NESTABLE_MATH_ENVS)
-        if re.match(rf'(\s*(%.*[\r\n]+)?)*\\begin\{{({envs_list})\}}', formula):
+        if re.match(rf'\s*(%.*(\n|\r\n?)\s*)*\\begin\{{({envs_list})\}}', formula):
             opening = closing = ''
         elif self.__maths_env:
             opening = '\\begin{%s}' % self.__maths_env

--- a/tests/test_typesetting.py
+++ b/tests/test_typesetting.py
@@ -44,6 +44,116 @@ class test_typesetting(unittest.TestCase):
         self.assertTrue(r'\begin{flalign*}' in str(doc))
         self.assertTrue(r'\end{flalign*}' in str(doc))
 
+    def test_non_nestable_math_envs_are_not_wrapped(self):
+        doc = LaTeXDocument(r'\begin{align}foobar\end{align}')
+        doc.set_displaymath(True)
+        self.assertNotIn(r'\[', str(doc))
+        self.assertNotIn(r'\]', str(doc))
+
+        doc.set_displaymath(False)
+        self.assertNotIn(r'\(', str(doc))
+        self.assertNotIn(r'\)', str(doc))
+
+    def test_non_nestable_math_envs_ignore_spaces(self):
+        doc = LaTeXDocument("""    \t   \t
+
+                \v        \r
+            \\begin{align*}blabla
+
+            \\end{align*}
+        """)
+        doc.set_displaymath(True)
+        self.assertNotIn(r'\[', str(doc))
+        self.assertNotIn(r'\]', str(doc))
+
+        doc.set_displaymath(False)
+        self.assertNotIn(r'\(', str(doc))
+        self.assertNotIn(r'\)', str(doc))
+
+        doc = LaTeXDocument(""" \t  \r \t
+
+         \t
+           \t\v \\begin{array}{r}
+            blabla
+
+            \\end{array}
+        """)
+        doc.set_displaymath(True)
+        self.assertIn(r'\[', str(doc))
+        self.assertIn(r'\]', str(doc))
+
+        doc.set_displaymath(False)
+        self.assertIn(r'\(', str(doc))
+        self.assertIn(r'\)', str(doc))
+
+    def test_non_nestable_math_envs_ignore_comments_and_spaces(self):
+        doc = LaTeXDocument("""  \r  \t   \t % klap30alf;''vak309u1$&la
+                    %\\begin{pmatrix}asdfl;3\v
+
+                %
+            \\begin{eqnarray}blabla
+
+            \\end{eqnarray}
+        """)
+        doc.set_displaymath(True)
+        self.assertNotIn(r'\[', str(doc))
+        self.assertNotIn(r'\]', str(doc))
+
+        doc.set_displaymath(False)
+        self.assertNotIn(r'\(', str(doc))
+        self.assertNotIn(r'\)', str(doc))
+
+        doc = LaTeXDocument(""" \t  % a3k0'  a'ef4FAS \t
+                      \v \r
+         \t %                     \\begin{align}asd3%%33-uadsfjl3;lkja04
+
+
+           \t \\begin{array}{r}
+            blabla
+
+            \\end{array}
+        """)
+        doc.set_displaymath(True)
+        self.assertIn(r'\[', str(doc))
+        self.assertIn(r'\]', str(doc))
+
+        doc.set_displaymath(False)
+        self.assertIn(r'\(', str(doc))
+        self.assertIn(r'\)', str(doc))
+
+    def test_non_nestable_math_envs_ignore_comments_and_spaces_only(self):
+        doc = LaTeXDocument("""  \r  \t   \t % klap30alf;''vak309u1$&la
+                    %\\begin{align*}asdfl;3\v
+
+              f  %
+            \\begin{eqnarray}blabla
+
+            \\end{eqnarray}
+        """)
+        doc.set_displaymath(True)
+        self.assertIn(r'\[', str(doc))
+        self.assertIn(r'\]', str(doc))
+
+        doc.set_displaymath(False)
+        self.assertIn(r'\(', str(doc))
+        self.assertIn(r'\)', str(doc))
+
+        doc = LaTeXDocument(""" \t  % a3k0'  a'ef4FAS \t
+                 \\     \v \r
+         \t %                     \\begin{align}asd3%%33-uadsfjl3;lkja04
+
+
+           \t \\begin{array}{r}
+            blabla
+        """)
+        doc.set_displaymath(True)
+        self.assertIn(r'\[', str(doc))
+        self.assertIn(r'\]', str(doc))
+
+        doc.set_displaymath(False)
+        self.assertIn(r'\(', str(doc))
+        self.assertIn(r'\)', str(doc))
+
 
 ################################################################################
 


### PR DESCRIPTION
In order to fix #21, we try to detect math environments which cannot be used inside math environments by the following simple heuristic: If a formula begins immediately with an environment (optionally prefixed by any amount of whitespace and comments) and this environment is in a list of non-nestable math environments, then this formula is not wrapped in a standard math environment.

This probably does not cover all possible use cases, but it provides a simple and backwards compatible solution that should support the most common ones.