### PR TITLE
Use Pandoc's native AST elements when filtering and support including outsourced descriptions in EPUB

### DIFF
--- a/gleetex/__main__.py
+++ b/gleetex/__main__.py
@@ -301,12 +301,20 @@ class Main:
 
         processed = self.convert_images(
             doc, base_path, options.img_directory, options)
-        img_fmt = htmlhandling.HtmlImageFormatter(
-            base_path=os.path.join(base_path, options.img_directory),
-            link_prefix=options.url,
-            exclusion_file_path=options.exclusionfile,
-            is_epub=options.is_epub,
-        )
+        if options.pandocfilter:
+            img_fmt = pandoc.PandocAstImageFormatter(
+                base_path=os.path.join(base_path, options.img_directory),
+                link_prefix=options.url,
+                exclusion_file_path=options.exclusionfile,
+                is_epub=options.is_epub,
+            )
+        else:
+            img_fmt = htmlhandling.HtmlImageFormatter(
+                base_path=os.path.join(base_path, options.img_directory),
+                link_prefix=options.url,
+                exclusion_file_path=options.exclusionfile,
+                is_epub=options.is_epub,
+            )
         if options.replace_nonascii:
             img_fmt.set_replace_nonascii(True)
         if options.url:

--- a/gleetex/htmlhandling.py
+++ b/gleetex/htmlhandling.py
@@ -550,7 +550,7 @@ def write_html(file, document, formatter, excluded_formulas_heading):
                     chunk['pos'], chunk['formula'], chunk['path'], is_displaymath
                 )
             )
-        elif embed_excluded_formulas and (
+        elif not chunk.startswith('<!--') and embed_excluded_formulas and (
             match := closing_body_tag_pattern.search(chunk)
         ):
             # Write the rest of the body.

--- a/gleetex/htmlhandling.py
+++ b/gleetex/htmlhandling.py
@@ -266,7 +266,7 @@ def format_formula_paragraph(formula):
 class ImageFormatter:  # ToDo: localisation
     """ImageFormatter(is_epub=False)
 
-    Format converted formula to be included into HTML. A typical image
+    Format converted formula for a specific output format. A typical image
     attribute will contain the path to the image, style information, a CSS class
     to be used in custom CSS style sheets and an alternative text (the LaTeX
     source) for people who disabled images or for blind screen reader users.
@@ -474,8 +474,8 @@ class HtmlImageFormatter(ImageFormatter):
     def format_internal(self, image, link_label=None):
         link_start, link_end = ('', '')
         if link_label:
-            link_start = f'<a href="{link_label}">' if link_label else ''
-            link_end = '</a>' if link_label else ''
+            link_start = f'<a href="{link_label}">'
+            link_end = '</a>'
         escaped_formula = html.escape(image['formula'], quote=True)
         return (
             link_start

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -1,0 +1,76 @@
+from unittest import TestCase
+
+from gleetex.pandoc import PandocAstImageFormatter as Formatter
+
+
+class PandocAstImageFormatterTest(TestCase):
+    # As most things are already tested in `test_htmlhandling.HtmlImageTest`,
+    # we only test things specific to the Pandoc AST handling here.
+
+    def test_height_width_depth_formula_imgpath_included(self):
+        formula = r'a = b^2 + x^3 - \frac{3x^7 \cdot 3}{\alpha \beta \gamma}'
+        path = 'foo.png'
+        ast = str(Formatter().format(
+            {'depth': 99, 'height': 88, 'width': 77}, formula, path,
+        ))
+        self.assertIn("['height', '88", ast)
+        self.assertIn("['width', '77", ast)
+        self.assertIn('99', ast)
+        self.assertIn(formula.replace('\\', '\\\\'), ast)
+        self.assertIn(path, ast)
+
+        formula = r'\lambda x - 52\rho = 33^\alpha^\beta'
+        ast = str(Formatter().format(
+            {'depth': 39, 'height': 21, 'width': 2}, formula, path,
+        ))
+        self.assertIn("['height', '21", ast)
+        self.assertIn("['width', '2", ast)
+        self.assertIn('39', ast)
+        self.assertIn(formula.replace('\\', '\\\\'), ast)
+        self.assertIn(path, ast)
+
+        formula = r'\phi \sin(\gamma x) \cos(xyz - 3)'
+        path = 'bar.svg'
+        ast = str(Formatter(is_epub=True).format(
+            {'depth': 24, 'height': 11, 'width': 53}, formula, path,
+        ))
+        self.assertIn("['height', '11", ast)
+        self.assertIn("['width', '53", ast)
+        self.assertIn('24', ast)
+        self.assertIn(formula.replace('\\', '\\\\'), ast)
+        self.assertIn(path, ast)
+
+    def test_outsourced_descriptions_are_link(self):
+        ast = Formatter().format(
+            {'depth': 39, 'height': 21, 'width': 2}, 'a + b +' * 100,
+            'foo.png',
+        )
+        self.assertEqual(ast['t'], 'Link')
+
+        ast = Formatter().format(
+            {'depth': 12, 'height': 1, 'width': 24}, r'\lambda x - q +' * 100,
+            'foo.png',
+        )
+        self.assertEqual(ast['t'], 'Link')
+
+    def test_outsourced_descriptions_contain_all_information(self):
+        formula = r'a = b^2 + x^3 - \frac{3x^7 \cdot 3}{\alpha \beta \gamma}' * 100
+        path = 'foo.png'
+        ast = str(Formatter().format(
+            {'depth': 99, 'height': 88, 'width': 77}, formula, path,
+        ))
+        self.assertIn("['height', '88", ast)
+        self.assertIn("['width', '77", ast)
+        self.assertIn('99', ast)
+        self.assertIn(formula[:20].replace('\\', '\\\\'), ast)
+        self.assertIn(path, ast)
+
+        formula = r'\lambda x - 52\rho = 33^\alpha^\beta' * 100
+        ast = str(Formatter(is_epub=True).format(
+            {'depth': 39, 'height': 21, 'width': 2}, formula, path,
+        ))
+        self.assertIn("['height', '21", ast)
+        self.assertIn("['width', '2", ast)
+        self.assertIn('39', ast)
+        self.assertIn(formula[:20].replace('\\', '\\\\'), ast)
+        self.assertIn(path, ast)


### PR DESCRIPTION
- [x] When using GladTeX as Pandoc (JSON) filter, native 'Link' and 'Image' AST elements are now used instead of using 'RawInline' HTML content with very limited output format support (closes #19).
- [x] Support appending outsourced formula descriptions at the end of a document in an `<aside>` for easier EPUB creation (closes #15).

## Remaining issues

- [x] When embedding the excluded formulas in an HTML file they are currently prepended before the first `</body>` found, even if it was commented out.
- [ ] The same long formulas generate the same IDs in the document and only one description to one of them. This could probably be fixed by appending the position at the end of the ID.
- ~~Simplify and abstract Pandoc AST handling, e.g. by defining wrappers.~~ See #29.
- [x] Title case 'Excluded formulas' section header
- [x] Add `-I` short option for `--embed-excluded-formulas`