### PR TITLE
Fix output option `-o` to really use the provided value

### DIFF
--- a/gleetex/__main__.py
+++ b/gleetex/__main__.py
@@ -274,6 +274,7 @@ class Main:
         # check which output file name to use
         base_path = ''
         if options.output:
+            output = options.output
             base_path = os.path.dirname(options.output)
         elif options.input != '-':
             output = os.path.splitext(options.input)[0] + '.html'


### PR DESCRIPTION
Previously, the value passed to `-o` was ignored if it differed from `-` and the output was written to stdout. Now the output should actually be written to the file provided as argument.

Fixes #25.