### PR TITLE
Abstract sink output handling for excluded formulas

### DIFF
--- a/gleetex/__main__.py
+++ b/gleetex/__main__.py
@@ -321,9 +321,6 @@ class Main:
         # Convert `None` to `False`.
         options.embed_excluded_formulas = bool(options.embed_excluded_formulas)
 
-        if options.embed_excluded_formulas:
-            options.exclusionfile = None
-
         if not options.dpi and not options.fontsize:
             # Set default font size iff neither `-r` nor `-f` have been pased.
             options.fontsize = 12
@@ -341,19 +338,27 @@ class Main:
 
         processed = self.convert_images(
             doc, base_path, options.img_directory, options)
+        if options.embed_excluded_formulas:
+            excluded_formula_output = (
+                sink.PandocAppended()
+                if options.pandocfilter
+                else sink.HtmlAppended()
+            )
+        else:
+            excluded_formula_output = sink.HtmlExternalFile(options.exclusionfile)
         if options.pandocfilter:
             img_fmt = pandoc.PandocAstImageFormatter(
                 base_path=os.path.join(base_path, options.img_directory),
                 link_prefix=options.url,
-                exclusion_file_path=options.exclusionfile,
                 is_epub=options.is_epub,
+                excluded_formula_output=excluded_formula_output,
             )
         else:
             img_fmt = htmlhandling.HtmlImageFormatter(
                 base_path=os.path.join(base_path, options.img_directory),
                 link_prefix=options.url,
-                exclusion_file_path=options.exclusionfile,
                 is_epub=options.is_epub,
+                excluded_formula_output=excluded_formula_output,
             )
         if options.replace_nonascii:
             img_fmt.set_replace_nonascii(True)
@@ -379,14 +384,15 @@ class Main:
                     file, processed, img_fmt, options.excluded_formulas_heading,
                 )
 
-        if not options.embed_excluded_formulas and img_fmt.get_excluded():
-            # ToDo: make sink type an argument
-            sink_type = sink.SinkType.html_file
-            try:
-                sink.EXCLUSION_FORMULA_SINKS[sink_type](
-                    img_fmt.get_exclusion_file_path(), img_fmt.get_excluded())
-            except KeyError:
-                raise NotImplementedError() from None
+        if (
+            not excluded_formula_output.appends_to_document()
+            and img_fmt.get_excluded()
+        ):
+            sink.write_excluded_formulas(
+                excluded_formula_output,
+                img_fmt,
+                options.excluded_formulas_heading,
+            )
 
     def convert_images(self, parsed_document, base_path, img_dir, options):
         """Convert all formulas to images and store file path and equation in a

--- a/gleetex/__main__.py
+++ b/gleetex/__main__.py
@@ -384,10 +384,7 @@ class Main:
                     file, processed, img_fmt, options.excluded_formulas_heading,
                 )
 
-        if (
-            not excluded_formula_output.appends_to_document()
-            and img_fmt.get_excluded()
-        ):
+        if not excluded_formula_output.appends_to_document() and img_fmt.get_excluded():
             sink.write_excluded_formulas(
                 excluded_formula_output,
                 img_fmt,

--- a/gleetex/htmlhandling.py
+++ b/gleetex/htmlhandling.py
@@ -24,7 +24,6 @@ from . import typesetting
 # match HTML 4 and 5
 CHARSET_PATTERN = re.compile(
     rb'(?:content="text/html; charset=(.*?)"|charset="(.*?)")')
-_UNSET = object()
 
 
 class ParseException(Exception):
@@ -284,9 +283,9 @@ class ImageFormatter:  # ToDo: localisation
     *   `base_path=""`: base path where images are stored, e.g. "images"
     *   `link_prefix=""`: a prefix which should be added to generated links, e.g.
         `"https://example.com/img/"`
-    *   `exclusion_file_path=""`: backward-compatible shorthand for the output
-        used for excluded formulas; `None` indicates formulas should be
-        appended to the current document
+    *   `exclusion_file_path=""`: backward-compatible shorthand describing
+        where excluded formulas are written; `None` keeps the historic
+        "append to the current document" behaviour
     *   `excluded_formula_output`: explicit output abstraction used for
         excluded formulas
     *   `is_epub`: round height/width of the linked images to comply with the
@@ -309,7 +308,7 @@ class ImageFormatter:  # ToDo: localisation
     EXCLUDED_ID_PREFIX = 'gladtex-excl-'
 
     def __init__(self, base_path=None, link_prefix='',
-                 exclusion_file_path=_UNSET, is_epub=False,
+                 exclusion_file_path=sink.EXCLUSION_FILE_NAME, is_epub=False,
                  excluded_formula_output=None):
         self.__inline_maxlength = 100
         self._excluded_formulas = collections.OrderedDict()
@@ -321,39 +320,34 @@ class ImageFormatter:  # ToDo: localisation
         self._link_prefix = link_prefix if link_prefix else ''
         base_path = ("" if not base_path else base_path)
         self._excluded_formula_output = self._normalise_excluded_formula_output(
-            base_path, excluded_formula_output, exclusion_file_path,
+            base_path, exclusion_file_path, excluded_formula_output,
         )
         self._excluded_formula_output.validate()
 
     @abstractmethod
     def _default_appended_excluded_formula_output(self):
-        """Return the explicit output used for appended excluded formulas."""
+        """Return the appended output used for `exclusion_file_path=None`.
+
+        This keeps the legacy constructor argument working while allowing
+        callers to pass an explicit excluded-formula output object.
+        """
 
     def _normalise_excluded_formula_output(
-        self, base_path, excluded_formula_output, exclusion_file_path
+        self, base_path, exclusion_file_path, excluded_formula_output
     ):
-        if (
-            excluded_formula_output is not None
-            and exclusion_file_path is not _UNSET
-        ):
-            raise ValueError(
-                '`excluded_formula_output` and `exclusion_file_path` '
-                'cannot be used together',
-            )
-
         if excluded_formula_output is None:
-            if exclusion_file_path is _UNSET:
-                excluded_formula_output = sink.HtmlExternalFile(
-                    sink.EXCLUSION_FILE_NAME,
-                )
-            elif exclusion_file_path is None:
-                excluded_formula_output = (
+            if exclusion_file_path is None:
+                excluded_formula_output = \
                     self._default_appended_excluded_formula_output()
-                )
             else:
                 excluded_formula_output = sink.HtmlExternalFile(
                     exclusion_file_path,
                 )
+        elif exclusion_file_path != sink.EXCLUSION_FILE_NAME:
+            raise ValueError(
+                '`excluded_formula_output` and `exclusion_file_path` '
+                'cannot be combined with a non-default exclusion file path',
+            )
 
         return excluded_formula_output.resolve_base_path(base_path)
 
@@ -362,13 +356,7 @@ class ImageFormatter:  # ToDo: localisation
 
         May be None.
         """
-        output = self.get_excluded_formula_output()
-        if (
-            isinstance(output, sink.ExternalExcludedFormulaOutput)
-            and hasattr(output, 'exclusion_filename')
-        ):
-            return output.exclusion_filename if output.exclusion_filename else None
-        return None
+        return self.get_excluded_formula_output().get_exclusion_file_path()
 
     def get_excluded_formula_output(self):
         """Return the configured output abstraction for excluded formulas."""
@@ -584,9 +572,11 @@ def write_html(file, document, formatter, excluded_formulas_heading):
             # Write the rest of the body.
             file.write(chunk[: match.span()[0]])
 
-            bound_excluded_formula_output = excluded_formula_output.bind_target(file)
             sink.write_excluded_formulas(
-                bound_excluded_formula_output, formatter, excluded_formulas_heading,
+                excluded_formula_output,
+                formatter,
+                excluded_formulas_heading,
+                target=file,
             )
 
             # Write the rest of the document.
@@ -596,7 +586,9 @@ def write_html(file, document, formatter, excluded_formulas_heading):
 
     if match is None and embed_excluded_formulas:
         # Malformed document with no `</body>`, just append the excluded formulas.
-        bound_excluded_formula_output = excluded_formula_output.bind_target(file)
         sink.write_excluded_formulas(
-            bound_excluded_formula_output, formatter, excluded_formulas_heading,
+            excluded_formula_output,
+            formatter,
+            excluded_formulas_heading,
+            target=file,
         )

--- a/gleetex/htmlhandling.py
+++ b/gleetex/htmlhandling.py
@@ -16,7 +16,6 @@ import collections
 import enum
 import html
 import os
-import posixpath
 import re
 
 from . import sink
@@ -25,6 +24,7 @@ from . import typesetting
 # match HTML 4 and 5
 CHARSET_PATTERN = re.compile(
     rb'(?:content="text/html; charset=(.*?)"|charset="(.*?)")')
+_UNSET = object()
 
 
 class ParseException(Exception):
@@ -284,10 +284,11 @@ class ImageFormatter:  # ToDo: localisation
     *   `base_path=""`: base path where images are stored, e.g. "images"
     *   `link_prefix=""`: a prefix which should be added to generated links, e.g.
         `"https://example.com/img/"`
-    *   `exclusion_file_path=""`: the path which formula descriptions are
-        written to which exceed a certain threshold that doesn't fit into the
-        alt tag of the `img` tag, or `None` to indicate that excluded formulas
-        are written in the same document they appear in
+    *   `exclusion_file_path=""`: backward-compatible shorthand for the output
+        used for excluded formulas; `None` indicates formulas should be
+        appended to the current document
+    *   `excluded_formula_output`: explicit output abstraction used for
+        excluded formulas
     *   `is_epub`: round height/width of the linked images to comply with the
         EPUB standard.
 
@@ -308,7 +309,8 @@ class ImageFormatter:  # ToDo: localisation
     EXCLUDED_ID_PREFIX = 'gladtex-excl-'
 
     def __init__(self, base_path=None, link_prefix='',
-                 exclusion_file_path=sink.EXCLUSION_FILE_NAME, is_epub=False):
+                 exclusion_file_path=_UNSET, is_epub=False,
+                 excluded_formula_output=None):
         self.__inline_maxlength = 100
         self._excluded_formulas = collections.OrderedDict()
         self.__excluded_formula_count = 0
@@ -318,23 +320,59 @@ class ImageFormatter:  # ToDo: localisation
         self.__replace_nonascii = False
         self._link_prefix = link_prefix if link_prefix else ''
         base_path = ("" if not base_path else base_path)
-        self._exclusion_filepath = exclusion_file_path
-        if self._exclusion_filepath is not None:
-            self._exclusion_filepath = posixpath.join(
-                base_path, self._exclusion_filepath,
+        self._excluded_formula_output = self._normalise_excluded_formula_output(
+            base_path, excluded_formula_output, exclusion_file_path,
+        )
+        self._excluded_formula_output.validate()
+
+    @abstractmethod
+    def _default_appended_excluded_formula_output(self):
+        """Return the explicit output used for appended excluded formulas."""
+
+    def _normalise_excluded_formula_output(
+        self, base_path, excluded_formula_output, exclusion_file_path
+    ):
+        if (
+            excluded_formula_output is not None
+            and exclusion_file_path is not _UNSET
+        ):
+            raise ValueError(
+                '`excluded_formula_output` and `exclusion_file_path` '
+                'cannot be used together',
             )
-            if os.path.exists(self._exclusion_filepath) and not os.access(
-                self._exclusion_filepath, os.W_OK,
-            ):
-                raise OSError(f'file {self._exclusion_filepath} not writable')
+
+        if excluded_formula_output is None:
+            if exclusion_file_path is _UNSET:
+                excluded_formula_output = sink.HtmlExternalFile(
+                    sink.EXCLUSION_FILE_NAME,
+                )
+            elif exclusion_file_path is None:
+                excluded_formula_output = (
+                    self._default_appended_excluded_formula_output()
+                )
+            else:
+                excluded_formula_output = sink.HtmlExternalFile(
+                    exclusion_file_path,
+                )
+
+        return excluded_formula_output.resolve_base_path(base_path)
 
     def get_exclusion_file_path(self):
-        """Return the path to the file to which formulas will be excluded too
-        if their description exceeds the alt attribute length.
+        """Return the external exclusion file path if the output uses one.
 
         May be None.
         """
-        return self._exclusion_filepath if self._exclusion_filepath else None
+        output = self.get_excluded_formula_output()
+        if (
+            isinstance(output, sink.ExternalExcludedFormulaOutput)
+            and hasattr(output, 'exclusion_filename')
+        ):
+            return output.exclusion_filename if output.exclusion_filename else None
+        return None
+
+    def get_excluded_formula_output(self):
+        """Return the configured output abstraction for excluded formulas."""
+        return self._excluded_formula_output
 
     def set_replace_nonascii(self, flag):
         """If True, non-ascii characters will be replaced through their LaTeX
@@ -353,16 +391,6 @@ class ImageFormatter:  # ToDo: localisation
     def set_inline_math_css_class(self, css):
         """set css class for inline math."""
         self._css['inline'] = css
-
-    @abstractmethod
-    def _generate_link_destination(self, excluded_label):
-        """Generate the link to an excluded formula, consisting either of path
-        and label or just a label.
-
-        The label is generated uniquely for each label by this function.
-        This function needs to be customised by implementors, e.g. to
-        return "foo.html#formula" or "#formula", etc.
-        """
 
     def set_display_math_css_class(self, css):
         """set css class for display math."""
@@ -473,7 +501,9 @@ class ImageFormatter:  # ToDo: localisation
         if len(formula) > self.__inline_maxlength:
             excluded_label = self._next_excluded_label()
             shortened_data['formula'] = f"{formula[:self.__inline_maxlength]}..."
-            link_destination = self._generate_link_destination(excluded_label)
+            link_destination = self._excluded_formula_output.get_link_destination(
+                excluded_label, self._link_prefix,
+            )
             image_anchor_id = ImageFormatter.get_excluded_image_anchor_id(
                 excluded_label
             )
@@ -493,11 +523,8 @@ class HtmlImageFormatter(ImageFormatter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _generate_link_destination(self, excluded_label):
-        exclusion_filelink = posixpath.join(
-            self._link_prefix, self._exclusion_filepath
-        ) if self._exclusion_filepath is not None else ''
-        return f'{exclusion_filelink}#{excluded_label}'
+    def _default_appended_excluded_formula_output(self):
+        return sink.HtmlAppended()
 
     def format_internal(self, image, full_formula, link_label=None, image_id=None):
         link_start, link_end = ('', '')
@@ -525,19 +552,6 @@ class HtmlImageFormatter(ImageFormatter):
     def add_excluded(self, label, image):
         self._excluded_formulas[label] = image['formula']
 
-
-def _write_excluded_formula_section(file, formatter, excluded_formulas_heading):
-    """Write all excluded formulas in an `<aside>` section to `file`."""
-    file.write(f'<aside><h1>{excluded_formulas_heading}</h1>\n')
-
-    for label, formula in formatter.get_excluded().items():
-        file.write(
-            f'<p><a href="#{formatter.get_excluded_image_anchor_id(label)}"'
-            f' id="{label}"><pre>{html.escape(formula)}</pre></a></p>\n',
-        )
-
-    file.write('</aside>')
-
 def write_html(file, document, formatter, excluded_formulas_heading):
     """Processed HTML documents are made up of raw HTML chunks which are
     written back unaltered and of a processed image.
@@ -547,15 +561,14 @@ def write_html(file, document, formatter, excluded_formulas_heading):
     supplied formatter and the result is written to the given (open)
     file handle.
 
-    If the value returned by `formatter.get_exclusion_file_path()` is
-    `None` and there are excluded formulas, the excluded formulas will
+    If the formatter uses an appended excluded-formula output and there
+    are excluded formulas, they will
     be embedded at the end of the document in an HTML `<aside>` element
     with the heading `excluded_formulas_heading`.
     """
     closing_body_tag_pattern = re.compile(r'<\s*/\s*body\s*>', re.IGNORECASE)
-    embed_excluded_formulas = (
-        formatter.get_exclusion_file_path() is None and formatter.get_excluded()
-    )
+    excluded_formula_output = formatter.get_excluded_formula_output()
+    embed_excluded_formulas = excluded_formula_output.appends_to_document()
     match = None
     for chunk in document:
         if isinstance(chunk, dict):
@@ -571,7 +584,10 @@ def write_html(file, document, formatter, excluded_formulas_heading):
             # Write the rest of the body.
             file.write(chunk[: match.span()[0]])
 
-            _write_excluded_formula_section(file, formatter, excluded_formulas_heading)
+            bound_excluded_formula_output = excluded_formula_output.bind_target(file)
+            sink.write_excluded_formulas(
+                bound_excluded_formula_output, formatter, excluded_formulas_heading,
+            )
 
             # Write the rest of the document.
             file.write(chunk[match.span()[0] :])
@@ -580,4 +596,7 @@ def write_html(file, document, formatter, excluded_formulas_heading):
 
     if match is None and embed_excluded_formulas:
         # Malformed document with no `</body>`, just append the excluded formulas.
-        _write_excluded_formula_section(file, formatter, excluded_formulas_heading)
+        bound_excluded_formula_output = excluded_formula_output.bind_target(file)
+        sink.write_excluded_formulas(
+            bound_excluded_formula_output, formatter, excluded_formulas_heading,
+        )

--- a/gleetex/pandoc/__init__.py
+++ b/gleetex/pandoc/__init__.py
@@ -18,21 +18,17 @@ It works in these parsses:
 """
 
 import json
-import posixpath
 
+from .. import sink
 from ..htmlhandling import ImageFormatter
 from .ast import (
     Div,
-    Heading,
-    InlineCode,
     InlineImage,
     InlineLink,
     InlineText,
     Math,
     MathType,
     Paragraph,
-    RawBlock,
-    RawFormat,
     Span,
     ast_root_blocks,
     foreach_element,
@@ -172,27 +168,6 @@ def _promote_display_error_placeholders(ast):
 
     traverse(ast)
 
-
-def _generate_excluded_formula_blocks(formatter, excluded_formulas_heading):
-    """Return the `<aside>` section Pandoc AST blocks with all excluded formulas."""
-    formula_paragraphs = [
-        Paragraph([
-            InlineLink(
-                [InlineCode(formula)],
-                url=f"#{formatter.get_excluded_image_anchor_id(label)}",
-                id=label,
-            ),
-        ])
-        for label, formula in formatter.get_excluded().items()
-    ]
-
-    return [block.to_json() for block in (
-        RawBlock(RawFormat.HTML, "<aside>"),
-        Heading([InlineText(excluded_formulas_heading)], level=1),
-        *formula_paragraphs,
-        RawBlock(RawFormat.HTML, "</aside>"),
-    )]
-
 def write_pandoc_ast(file, document, formatter, excluded_formulas_heading):
     """Replace `Math` elements from a Pandoc AST with the formatted elements.
 
@@ -206,8 +181,8 @@ def write_pandoc_ast(file, document, formatter, excluded_formulas_heading):
     `PandocJsonAstParseError` or a `UnsupportedPandocJsonAstVersionError` is
     raised, respectively.
 
-    If the value returned by `formatter.get_exclusion_file_path()` is
-    `None` and there are excluded formulas, the excluded formulas will
+    If the formatter uses an appended excluded-formula output and there
+    are excluded formulas, they will
     be embedded at the end of the document in an HTML `<aside>` element
     with the heading `excluded_formulas_heading`.
     """
@@ -215,9 +190,13 @@ def write_pandoc_ast(file, document, formatter, excluded_formulas_heading):
     ast_blocks = ast_root_blocks(ast)
     replace_formulas_in_ast(formatter, ast_blocks, formulas)
 
-    if formatter.get_exclusion_file_path() is None and formatter.get_excluded():
-        ast_blocks.extend(
-            _generate_excluded_formula_blocks(formatter, excluded_formulas_heading)
+    excluded_formula_output = formatter.get_excluded_formula_output()
+    if excluded_formula_output.appends_to_document():
+        bound_excluded_formula_output = excluded_formula_output.bind_target(ast_blocks)
+        sink.write_excluded_formulas(
+            bound_excluded_formula_output,
+            formatter,
+            excluded_formulas_heading,
         )
 
     file.write(json.dumps(ast))
@@ -229,11 +208,8 @@ class PandocAstImageFormatter(ImageFormatter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _generate_link_destination(self, excluded_label):
-        exclusion_filelink = posixpath.join(
-            self._link_prefix, self._exclusion_filepath,
-        ) if self._exclusion_filepath is not None else ''
-        return f'{exclusion_filelink}#{excluded_label}'
+    def _default_appended_excluded_formula_output(self):
+        return sink.PandocAppended()
 
     def format_internal(self, image, full_formula, link_label=None, image_id=None):
         ast_node = InlineImage(

--- a/gleetex/pandoc/__init__.py
+++ b/gleetex/pandoc/__init__.py
@@ -192,11 +192,11 @@ def write_pandoc_ast(file, document, formatter, excluded_formulas_heading):
 
     excluded_formula_output = formatter.get_excluded_formula_output()
     if excluded_formula_output.appends_to_document():
-        bound_excluded_formula_output = excluded_formula_output.bind_target(ast_blocks)
         sink.write_excluded_formulas(
-            bound_excluded_formula_output,
+            excluded_formula_output,
             formatter,
             excluded_formulas_heading,
+            target=ast_blocks,
         )
 
     file.write(json.dumps(ast))

--- a/gleetex/sink.py
+++ b/gleetex/sink.py
@@ -8,10 +8,27 @@ its converted equivalent. Tis decouples the GleeTeX-internal logic from HTML and
 allows using it e.g. as a filter for Pandoc (JSON-encoded).
 """
 
+from abc import ABC, abstractmethod
 import enum
 import html
+import os
+import posixpath
 
 EXCLUSION_FILE_NAME = 'excluded-descriptions.html'
+
+__all__ = [
+    'EXCLUSION_FILE_NAME',
+    'AppendedExcludedFormulaOutput',
+    'ExcludedFormulaOutput',
+    'ExternalExcludedFormulaOutput',
+    'HtmlAppended',
+    'HtmlExternalFile',
+    'HtmlOutput',
+    'PandocOutput',
+    'PandocAppended',
+    'SinkType',
+    'write_excluded_formulas',
+]
 
 # Todo: localisation
 HTML_TEMPLATE_HEAD = """
@@ -30,21 +47,189 @@ class SinkType(enum.Enum):
     drop = 0
     html_body = 1
     html_file = 2
-    json_file = 2
-    inline = 3
-
-def html_write_excluded_file(exclusion_filename, formatted_excluded_formulas):
-    """Write back list of excluded formulas.
-    Formulas that are too long or too complex for the alt tag are excluded to a
-    separate file. This function initiates the writing process to the external
-    file."""
-    with open(exclusion_filename, 'w', encoding='UTF-8') as file:
-        file.write(HTML_TEMPLATE_HEAD)
-        _html_write_excluded(file, formatted_excluded_formulas)
-        file.write('\n</body>\n</html>\n')
+    json_file = 3
+    inline = 4
 
 
-def html_write_excluded_body(exclusion_filename, formatted_excluded_formulas):
+class ExcludedFormulaOutput(ABC):
+    """Describe where and how excluded formulas should be written."""
+
+    def __init__(self, sink_type):
+        self.sink_type = sink_type
+
+    def appends_to_document(self):
+        """Return whether formulas are appended to the main document."""
+        return False
+
+    def resolve_base_path(self, base_path):
+        """Return an output object resolved against `base_path`."""
+        return self
+
+    def validate(self):
+        """Validate the configured output target."""
+
+    def bind_target(self, target):
+        """Return an output object bound to `target`."""
+        del target
+        return self
+
+    @abstractmethod
+    def get_link_destination(self, excluded_label, link_prefix=''):
+        """Return the link destination for `excluded_label`."""
+
+    @abstractmethod
+    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
+        """Write excluded formulas using this output configuration."""
+
+
+class ExternalExcludedFormulaOutput(ExcludedFormulaOutput):
+    """Excluded formulas written to an external output."""
+
+
+class AppendedExcludedFormulaOutput(ExcludedFormulaOutput):
+    """Excluded formulas appended to the current document."""
+
+    def appends_to_document(self):
+        return True
+
+
+class HtmlOutput(ExcludedFormulaOutput):
+    """Base class for excluded-formula outputs rendered as HTML."""
+
+    def _render_html_entries(self, formatter, with_backlinks):
+        entries = []
+        for label, formula in formatter.get_excluded().items():
+            escaped_formula = html.escape(formula)
+            if with_backlinks:
+                image_anchor_id = formatter.get_excluded_image_anchor_id(label)
+                entries.append(
+                    f'<p><a href="#{image_anchor_id}" id="{label}">'
+                    f'<pre>{escaped_formula}</pre></a></p>\n',
+                )
+            else:
+                entries.append(f'<a id="{label}"><pre>{escaped_formula}</pre></a>\n')
+        return ''.join(entries)
+
+
+class HtmlExternalFile(HtmlOutput, ExternalExcludedFormulaOutput):
+    """Write excluded formulas to a separate HTML file."""
+
+    def __init__(self, exclusion_filename):
+        super().__init__(SinkType.html_file)
+        self.exclusion_filename = exclusion_filename
+
+    def resolve_base_path(self, base_path):
+        if not base_path or posixpath.isabs(self.exclusion_filename):
+            return self
+        return HtmlExternalFile(posixpath.join(base_path, self.exclusion_filename))
+
+    def validate(self):
+        if os.path.exists(self.exclusion_filename) and not os.access(
+            self.exclusion_filename, os.W_OK,
+        ):
+            raise OSError(f'file {self.exclusion_filename} not writable')
+
+    def get_link_destination(self, excluded_label, link_prefix=''):
+        exclusion_filelink = posixpath.join(
+            link_prefix, self.exclusion_filename,
+        ) if link_prefix else self.exclusion_filename
+        return f'{exclusion_filelink}#{excluded_label}'
+
+    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
+        del excluded_formulas_heading
+        with open(self.exclusion_filename, 'w', encoding='UTF-8') as file:
+            file.write(HTML_TEMPLATE_HEAD)
+            file.write(self._render_html_entries(formatter, with_backlinks=False))
+            file.write('\n</body>\n</html>\n')
+        return None
+
+
+class HtmlAppended(HtmlOutput, AppendedExcludedFormulaOutput):
+    """Append excluded formulas to the generated HTML document."""
+
+    def __init__(self, target=None):
+        super().__init__(SinkType.html_body)
+        self.target = target
+
+    def bind_target(self, target):
+        return HtmlAppended(target)
+
+    def get_link_destination(self, excluded_label, link_prefix=''):
+        del link_prefix
+        return f'#{excluded_label}'
+
+    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
+        if self.target is None:
+            raise ValueError('HtmlAppended requires a target before writing')
+        heading = excluded_formulas_heading or 'Excluded Formulas'
+        self.target.write(
+            f'<aside><h1>{heading}</h1>\n'
+            f'{self._render_html_entries(formatter, with_backlinks=True)}'
+            '</aside>'
+        )
+        return None
+
+
+class PandocOutput(ExcludedFormulaOutput):
+    """Base class for excluded-formula outputs rendered as Pandoc AST."""
+
+
+class PandocAppended(PandocOutput, AppendedExcludedFormulaOutput):
+    """Append excluded formulas to a Pandoc AST."""
+
+    def __init__(self, target=None):
+        super().__init__(SinkType.json_file)
+        self.target = target
+
+    def bind_target(self, target):
+        return PandocAppended(target)
+
+    def get_link_destination(self, excluded_label, link_prefix=''):
+        del link_prefix
+        return f'#{excluded_label}'
+
+    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
+        if self.target is None:
+            raise ValueError('PandocAppended requires a target before writing')
+        from .pandoc.ast import (
+            Heading,
+            InlineCode,
+            InlineLink,
+            InlineText,
+            Paragraph,
+            RawBlock,
+            RawFormat,
+        )
+
+        heading = excluded_formulas_heading or 'Excluded Formulas'
+        formula_paragraphs = [
+            Paragraph([
+                InlineLink(
+                    [InlineCode(formula)],
+                    url=f"#{formatter.get_excluded_image_anchor_id(label)}",
+                    id=label,
+                ),
+            ])
+            for label, formula in formatter.get_excluded().items()
+        ]
+
+        self.target.extend([block.to_json() for block in (
+            RawBlock(RawFormat.HTML, "<aside>"),
+            Heading([InlineText(heading)], level=1),
+            *formula_paragraphs,
+            RawBlock(RawFormat.HTML, "</aside>"),
+        )])
+        return None
+
+
+def _html_write_excluded_file(exclusion_filename, formatted_excluded_formulas):
+    """Backward-compatible helper for the old sink API."""
+    output = HtmlExternalFile(exclusion_filename)
+    formatter = _LegacyExcludedFormulaFormatter(formatted_excluded_formulas)
+    output.write_excluded_formulas(formatter)
+
+
+def _html_write_excluded_body(exclusion_filename, formatted_excluded_formulas):
     with open(exclusion_filename, 'w', encoding='UTF-8') as file:
         _html_write_excluded(file, formatted_excluded_formulas)
 
@@ -56,7 +241,67 @@ def _html_write_excluded(file_obj, formatted_excluded_formulas):
 
 
 # Map the sink type to their processing function.
-EXCLUSION_FORMULA_SINKS = {
-    SinkType.html_file: html_write_excluded_file,
-    SinkType.html_body: html_write_excluded_body,
+_EXCLUSION_FORMULA_SINKS = {
+    SinkType.html_file: _html_write_excluded_file,
+    SinkType.html_body: _html_write_excluded_body,
 }
+
+
+class _LegacyExcludedFormulaFormatter:
+    """Adapter used to keep the old `write_excluded_formulas` signature working."""
+
+    def __init__(self, excluded_formulas):
+        self._excluded_formulas = excluded_formulas
+
+    def get_excluded(self):
+        return self._excluded_formulas
+
+    @staticmethod
+    def get_excluded_image_anchor_id(excluded_label):
+        return excluded_label
+
+
+def _write_excluded_formulas_legacy(
+    sink_type, exclusion_filename, formatted_excluded_formulas
+):
+    if not formatted_excluded_formulas:
+        return None
+
+    try:
+        writer = _EXCLUSION_FORMULA_SINKS[sink_type]
+    except KeyError:
+        raise NotImplementedError() from None
+
+    writer(exclusion_filename, formatted_excluded_formulas)
+    return None
+
+
+def write_excluded_formulas(output, *args):
+    """Write excluded formulas using either the legacy or the output-object API.
+
+    Legacy signature:
+        write_excluded_formulas(sink_type, exclusion_filename, formulas)
+
+    Preferred signature:
+        write_excluded_formulas(output, formatter, excluded_formulas_heading=None)
+    """
+    if isinstance(output, SinkType):
+        if len(args) != 2:
+            raise TypeError('legacy write_excluded_formulas expects 3 arguments')
+        return _write_excluded_formulas_legacy(output, args[0], args[1])
+
+    if not isinstance(output, ExcludedFormulaOutput):
+        raise TypeError('ExcludedFormulaOutput instance expected')
+
+    if len(args) not in {1, 2}:
+        raise TypeError(
+            'write_excluded_formulas expects output, formatter, '
+            '[excluded_formulas_heading]'
+        )
+
+    formatter = args[0]
+    excluded_formulas_heading = args[1] if len(args) == 2 else None
+    if not formatter.get_excluded():
+        return None
+    output.write_excluded_formulas(formatter, excluded_formulas_heading)
+    return None

--- a/gleetex/sink.py
+++ b/gleetex/sink.py
@@ -62,24 +62,29 @@ class ExcludedFormulaOutput(ABC):
         return False
 
     def resolve_base_path(self, base_path):
-        """Return an output object resolved against `base_path`."""
+        """Return this output with relative file paths resolved to `base_path`."""
         return self
 
     def validate(self):
-        """Validate the configured output target."""
+        """Validate configuration that can be checked without document data."""
 
-    def bind_target(self, target):
-        """Return an output object bound to `target`."""
-        del target
-        return self
+    def get_exclusion_file_path(self):
+        """Return the external exclusion file path used by this output, if any."""
+        return None
 
     @abstractmethod
     def get_link_destination(self, excluded_label, link_prefix=''):
         """Return the link destination for `excluded_label`."""
 
     @abstractmethod
-    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
-        """Write excluded formulas using this output configuration."""
+    def write_excluded_formulas(
+        self, formatter, excluded_formulas_heading=None, target=None
+    ):
+        """Write excluded formulas using this output configuration.
+
+        `target` is only used by outputs that append formulas to an existing
+        document or AST.
+        """
 
 
 class ExternalExcludedFormulaOutput(ExcludedFormulaOutput):
@@ -97,6 +102,7 @@ class HtmlOutput(ExcludedFormulaOutput):
     """Base class for excluded-formula outputs rendered as HTML."""
 
     def _render_html_entries(self, formatter, with_backlinks):
+        """Return rendered HTML snippets for the excluded formulas."""
         entries = []
         for label, formula in formatter.get_excluded().items():
             escaped_formula = html.escape(formula)
@@ -124,10 +130,15 @@ class HtmlExternalFile(HtmlOutput, ExternalExcludedFormulaOutput):
         return HtmlExternalFile(posixpath.join(base_path, self.exclusion_filename))
 
     def validate(self):
+        """Validate that an existing external exclusion file is writable."""
         if os.path.exists(self.exclusion_filename) and not os.access(
             self.exclusion_filename, os.W_OK,
         ):
             raise OSError(f'file {self.exclusion_filename} not writable')
+
+    def get_exclusion_file_path(self):
+        """Return the filename used for the external exclusion document."""
+        return self.exclusion_filename if self.exclusion_filename else None
 
     def get_link_destination(self, excluded_label, link_prefix=''):
         exclusion_filelink = posixpath.join(
@@ -135,8 +146,9 @@ class HtmlExternalFile(HtmlOutput, ExternalExcludedFormulaOutput):
         ) if link_prefix else self.exclusion_filename
         return f'{exclusion_filelink}#{excluded_label}'
 
-    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
-        del excluded_formulas_heading
+    def write_excluded_formulas(
+        self, formatter, _excluded_formulas_heading=None, target=None
+    ):
         with open(self.exclusion_filename, 'w', encoding='UTF-8') as file:
             file.write(HTML_TEMPLATE_HEAD)
             file.write(self._render_html_entries(formatter, with_backlinks=False))
@@ -151,18 +163,17 @@ class HtmlAppended(HtmlOutput, AppendedExcludedFormulaOutput):
         super().__init__(SinkType.html_body)
         self.target = target
 
-    def bind_target(self, target):
-        return HtmlAppended(target)
-
-    def get_link_destination(self, excluded_label, link_prefix=''):
-        del link_prefix
+    def get_link_destination(self, excluded_label, _link_prefix=''):
         return f'#{excluded_label}'
 
-    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
-        if self.target is None:
+    def write_excluded_formulas(
+        self, formatter, excluded_formulas_heading=None, target=None
+    ):
+        target = self.target if target is None else target
+        if target is None:
             raise ValueError('HtmlAppended requires a target before writing')
         heading = excluded_formulas_heading or 'Excluded Formulas'
-        self.target.write(
+        target.write(
             f'<aside><h1>{heading}</h1>\n'
             f'{self._render_html_entries(formatter, with_backlinks=True)}'
             '</aside>'
@@ -181,15 +192,14 @@ class PandocAppended(PandocOutput, AppendedExcludedFormulaOutput):
         super().__init__(SinkType.json_file)
         self.target = target
 
-    def bind_target(self, target):
-        return PandocAppended(target)
-
-    def get_link_destination(self, excluded_label, link_prefix=''):
-        del link_prefix
+    def get_link_destination(self, excluded_label, _link_prefix=''):
         return f'#{excluded_label}'
 
-    def write_excluded_formulas(self, formatter, excluded_formulas_heading=None):
-        if self.target is None:
+    def write_excluded_formulas(
+        self, formatter, excluded_formulas_heading=None, target=None
+    ):
+        target = self.target if target is None else target
+        if target is None:
             raise ValueError('PandocAppended requires a target before writing')
         from .pandoc.ast import (
             Heading,
@@ -213,7 +223,7 @@ class PandocAppended(PandocOutput, AppendedExcludedFormulaOutput):
             for label, formula in formatter.get_excluded().items()
         ]
 
-        self.target.extend([block.to_json() for block in (
+        target.extend([block.to_json() for block in (
             RawBlock(RawFormat.HTML, "<aside>"),
             Heading([InlineText(heading)], level=1),
             *formula_paragraphs,
@@ -276,14 +286,16 @@ def _write_excluded_formulas_legacy(
     return None
 
 
-def write_excluded_formulas(output, *args):
+def write_excluded_formulas(output, *args, target=None):
     """Write excluded formulas using either the legacy or the output-object API.
 
     Legacy signature:
         write_excluded_formulas(sink_type, exclusion_filename, formulas)
 
     Preferred signature:
-        write_excluded_formulas(output, formatter, excluded_formulas_heading=None)
+        write_excluded_formulas(
+            output, formatter, excluded_formulas_heading=None, target=None
+        )
     """
     if isinstance(output, SinkType):
         if len(args) != 2:
@@ -303,5 +315,7 @@ def write_excluded_formulas(output, *args):
     excluded_formulas_heading = args[1] if len(args) == 2 else None
     if not formatter.get_excluded():
         return None
-    output.write_excluded_formulas(formatter, excluded_formulas_heading)
+    output.write_excluded_formulas(
+        formatter, excluded_formulas_heading, target=target,
+    )
     return None

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -232,3 +232,19 @@ class MainTest(TestCase):
             placeholder["c"][1][0]["c"],
             [{"t": "Str", "c": "[LaTeX error]"}],
         )
+    def test_excluded_formulas_embedded_when_requested(self):
+        with open('testfile.htex', 'w') as f:
+            f.write(HTML_SKELETON.format(r"""
+                <p>This is a unremarkable document for <eq>testing
+                loooooooooooooooooooooooooooooooooooooong fooooooooormuuuuulas
+                ooooooooooooooooooooooooooooonly E=mc^2 \cdot \gamma</eq>.</p>
+            """))
+
+        Main().run(['prog', '--embed-excluded-formulas', 'testfile.htex'])
+        self.assertFalse(os.path.exists('excluded-descriptions.html'))
+
+        with open('testfile.html', 'r') as f:
+            html = f.read()
+        self.assertIn('<aside><h1>Excluded Formulas</h1>', html)
+        self.assertIn('id="gladtex-excl-000001"', html)
+        self.assertIn('href="#gladtex-img-gladtex-excl-000001"', html)

--- a/tests/test_htmlhandling.py
+++ b/tests/test_htmlhandling.py
@@ -223,7 +223,9 @@ class HtmlImageTest(unittest.TestCase):
         formula = '\\tau\\tau\gamma\delta' * 42
         img = htmlhandling.HtmlImageFormatter()
         formatted_img = img.format(self.pos, formula, 'foo.png')
-        sink.html_write_excluded_file(excl_filename, img.get_excluded())
+        sink.write_excluded_formulas(
+            img.get_excluded_formula_output(), img,
+        )
         external_file = read(excl_filename, 'r', encoding='utf-8')
         # find linked formula path
         href = re.search('href="(.*?)"', formatted_img)
@@ -254,6 +256,30 @@ class HtmlImageTest(unittest.TestCase):
         path, id = href.groups()[0].split('#')
         self.assertEqual(path, 'basepath/' + excl_filename)
         self.assertEqual(id, htmlhandling.ImageFormatter.EXCLUDED_ID_PREFIX + '000001')
+
+    def test_explicit_html_appended_output_uses_fragment_links(self):
+        formula = '\\tau\\tau\gamma\delta' * 42
+        img = htmlhandling.HtmlImageFormatter(
+            excluded_formula_output=sink.HtmlAppended(),
+        )
+        formatted_img = img.format(self.pos, formula, 'foo.png')
+        href = re.search('href="(.*?)"', formatted_img).groups()[0]
+        self.assertEqual(
+            href,
+            '#' + htmlhandling.ImageFormatter.EXCLUDED_ID_PREFIX + '000001',
+        )
+
+    def test_html_appended_can_be_initialised_with_target(self):
+        formula = '\\tau\\tau\gamma\delta' * 42
+        formatter = htmlhandling.HtmlImageFormatter(
+            excluded_formula_output=sink.HtmlAppended(),
+        )
+        formatter.format(self.pos, formula, 'foo.png')
+        out = io.StringIO()
+        sink.write_excluded_formulas(
+            sink.HtmlAppended(out), formatter, 'Excluded Formulas',
+        )
+        self.assertIn('<aside><h1>Excluded Formulas</h1>', out.getvalue())
 
     def test_identical_long_formulas_get_unique_excluded_labels(self):
         formula = '\\tau\\tau\gamma\delta' * 42
@@ -288,10 +314,37 @@ class HtmlImageTest(unittest.TestCase):
         img.format(self.pos, '\\tau' * 999, 'foo.png')
         img = htmlhandling.HtmlImageFormatter(exclusion_file_path=excl_filename)
         img.format(self.pos, '\\pi\\tau' * 666, 'foo_2.png')
-        sink.html_write_excluded_file(excl_filename, img.get_excluded())
+        sink.write_excluded_formulas(
+            img.get_excluded_formula_output(), img,
+        )
         data = read(excl_filename)
         self.assertTrue('\\tau' in data)
         self.assertTrue('\\pi' in data)
+
+    def test_write_html_embeds_excluded_formulas_for_explicit_output(self):
+        formatter = htmlhandling.HtmlImageFormatter(
+            excluded_formula_output=sink.HtmlAppended(),
+        )
+        out = io.StringIO()
+        htmlhandling.write_html(
+            out,
+            [
+                '<html><body><p>',
+                {
+                    'pos': self.pos,
+                    'formula': '\\tau' * 999,
+                    'path': 'foo.png',
+                    'displaymath': False,
+                },
+                '</p></body></html>',
+            ],
+            formatter,
+            'Excluded Formulas',
+        )
+        data = out.getvalue()
+        self.assertIn('<aside><h1>Excluded Formulas</h1>', data)
+        self.assertIn('id="gladtex-excl-000001"', data)
+        self.assertIn('href="#gladtex-img-gladtex-excl-000001"', data)
 
     def test_too_long_formulas_are_not_outsourced_if_not_configured(self):
         img = htmlhandling.HtmlImageFormatter('foo.html')

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -1,5 +1,8 @@
+import io
+import json
 from unittest import TestCase
 
+from gleetex import pandoc, sink
 from gleetex.pandoc import PandocAstImageFormatter as Formatter
 from gleetex.pandoc import ast
 
@@ -108,6 +111,60 @@ class PandocAstImageFormatterTest(TestCase):
         self.assertIn('39', ast)
         self.assertIn(formula[:20].replace('\\', '\\\\'), ast)
         self.assertIn(path, ast)
+
+    def test_explicit_pandoc_appended_output_uses_fragment_links(self):
+        ast_node = Formatter(
+            excluded_formula_output=sink.PandocAppended(),
+        ).format(
+            {'depth': 12, 'height': 1, 'width': 24},
+            r'\lambda x - q +' * 100,
+            'foo.png',
+        )
+        self.assertEqual(ast_node['c'][2][0], '#gladtex-excl-000001')
+
+    def test_pandoc_appended_can_be_initialised_with_target(self):
+        formula = r'\lambda x - q +' * 100
+        formatter = Formatter(excluded_formula_output=sink.PandocAppended())
+        formatter.format(
+            {'depth': 12, 'height': 1, 'width': 24}, formula, 'foo.png',
+        )
+        blocks = []
+        sink.write_excluded_formulas(
+            sink.PandocAppended(blocks), formatter, 'Excluded Formulas',
+        )
+        self.assertEqual(blocks[0]['c'][1], '<aside>')
+        self.assertEqual(blocks[-1]['c'][1], '</aside>')
+
+    def test_write_pandoc_ast_appends_excluded_formulas_for_explicit_output(self):
+        formula = r'\lambda x - q +' * 100
+        formatter = Formatter(excluded_formula_output=sink.PandocAppended())
+        ast_root = {
+            'pandoc-api-version': ast.SUPPORTED_AST_VERSION,
+            'meta': {},
+            'blocks': [
+                ast.Paragraph([ast.Math(formula)]).to_json(),
+            ],
+        }
+        formulas = [{
+            'pos': {'depth': 12, 'height': 1, 'width': 24},
+            'formula': formula,
+            'path': 'foo.png',
+            'displaymath': False,
+        }]
+        out = io.StringIO()
+        pandoc.write_pandoc_ast(
+            out, (ast_root, formulas), formatter, 'Excluded Formulas',
+        )
+        written_ast = json.loads(out.getvalue())
+        blocks = written_ast['blocks']
+        self.assertEqual(blocks[-4]['c'][1], '<aside>')
+        self.assertEqual(blocks[-3]['c'][2][0]['c'], 'Excluded Formulas')
+        self.assertEqual(blocks[-2]['c'][0]['c'][0][0], 'gladtex-excl-000001')
+        self.assertEqual(
+            blocks[-2]['c'][0]['c'][2][0],
+            '#gladtex-img-gladtex-excl-000001',
+        )
+        self.assertEqual(blocks[-1]['c'][1], '</aside>')
 
 
 class PandocAstTest(TestCase):


### PR DESCRIPTION
This changes the sink API for excluded formulas in two steps:
- hide the internal sink dispatch behind `write_excluded_formulas()`
- abstract excluded-formula output via explicit output objects

The new output model supports:
- writing excluded formulas to a separate HTML file
- appending excluded formulas to HTML output
- appending excluded formulas to Pandoc AST output

Tests:
- `python -m unittest tests.test_htmlhandling tests.test_pandoc tests.test___main__`
- `python -m unittest discover tests`
- manual CLI smoke tests for external and embedded excluded-formula output

Closes #43 